### PR TITLE
post nvim cleanup cwm

### DIFF
--- a/homedir/.bashrc
+++ b/homedir/.bashrc
@@ -168,6 +168,9 @@ export EDITOR="$VISUAL"
 # set fzf to use fd
 export FZF_DEFAULT_COMMAND="fdfind . $HOME $PROJECT_DIR -E '*node_modules*' -E '*vimwiki*' -E '*spark-3.2.1-bin-hadoop3.2*' -E '*aws-glue-libs*'"
 
+# set alt-c to search all directories
+export FZF_ALT_C_COMMAND="fdfind . $HOME $PROJECT_DIR --type d -E '*node_modules*' -E '*vimwiki*' -E '*spark-3.2.1-bin-hadoop3.2*' -E '*aws-glue-libs*'"
+
 # remaps capslock to escape on linux
 setxkbmap -option caps:escape
 

--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -41,9 +41,9 @@ set.splitright = true
 set.fillchars:append({vert = ' '})
 
 --easier file search
-vim.cmd('cabbrev vex Vex')
-vim.cmd('cabbrev ex Ex')
-vim.cmd('cabbrev sex Sex')
+vim.cmd('cabbrev vex Vexplore!')
+vim.cmd('cabbrev ex Explore')
+vim.cmd('cabbrev sex Sexplore')
 
 --remove banner in file explorer
 vim.cmd('let g:netrw_banner = 0')

--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -46,7 +46,7 @@ vim.cmd('cabbrev ex Explore')
 vim.cmd('cabbrev sex Sexplore')
 
 --remove banner in file explorer
-vim.cmd('let g:netrw_banner = 0')
+vim.g.netrw_banner = 0
 
 --quality of life key remaps
 vim.api.nvim_set_keymap('', ';', ':', {noremap = true})

--- a/neovim/lua/plugins.lua
+++ b/neovim/lua/plugins.lua
@@ -19,17 +19,17 @@ vim.call('plug#begin', '~/.vim/plugged') --specify plugin directory
 vim.call('plug#end')
 
 --Ultisnip options
+vim.g.UltiSnipsExpandTrigger = "<tab>"
+vim.g.UltiSnipsJumpForwardTrigger = "<tab>"
+vim.g.UltiSnipsJumpBackwardTrigger = "<s-tab>"
+vim.g.UltiSnipsEditSplit = "vertical"
 vim.cmd [[
-let g:UltiSnipsExpandTrigger="<tab>"
-let g:UltiSnipsJumpForwardTrigger="<tab>"
-let g:UltiSnipsJumpBackwardTrigger="<s-tab>"
 let g:UltiSnipsSnippetDirectories=[$HOME.'/.config/nvim/UltiSnips']
-let g:UltiSnipsEditSplit="vertical"
-cabbrev snip UltiSnipsEdit
 ]]
+vim.cmd('cabbrev snip UltiSnipsEdit')
 
 --CoC options
 vim.cmd [[
-let g:coc_global_extensions = ['coc-tsserver']
-let g:coc_disable_startup_warning = 1
+let g:coc_global_extensions=['coc-tsserver']
 ]]
+vim.g.coc_disable_startup_warning = 1


### PR DESCRIPTION
- cleaned up dev-setup.sh, added nim=nvim alias, & changed aliases from vim to nvim
- added install for fdfind, set fzf to use fd, & added an untracked local_vars file
- turned off limit on history size
- added setting to visualize tabs in nvim
- changed vim.keymap.set to vim.api.nvim_set_keymap for consistency
- added common function to aliases, shows n most common shell commands in history
- fixed 2 typos: missing } & missing {noremap = true}
- adjusted bashrc, init.lua, & macros.vim to allow gmk auth tool to work in vim
- added save to clipboard & init.lua reload keymaps to nvim
- made file search abbreviations more explicit
- moved g: commands out of vim.cmd blocks as much as possible
- set alt-c fzf command to use $HOME & $PROJECT_DIR
