### PR TITLE
nvim cleanup cwm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# dotfiles
+# Dotfiles
+![GitHub](https://img.shields.io/github/license/satetheus/dotfiles)
+![GitHub issues](https://img.shields.io/github/issues/satetheus/dotfiles)
+
 My dot files. Includes various aliases for commands I commonly use, bash & vim configurations, setup scripts to initialize/setup machines I use, & some git setup.
 The setup files add some functionality I find important. Things such as a fuzzy finder [(fzf)](https://github.com/junegunn/fzf), a faster grep [(sift)](https://github.com/svent/sift), & voice to text program for people who have paper-mache wrists like me [(talon voice)](https://talonvoice.com/).
 

--- a/homedir/.aliases
+++ b/homedir/.aliases
@@ -115,6 +115,11 @@ function g2ssh() {
     git remote set-url $names $newurl
 }
 
+# mkdir + cd
+function mkcd () {
+    mkdir "${1}" && cd "${1}"
+}
+
 #
 function preqs () {
     grep -i -r --no-filename --include \*.py 'import ' . | \
@@ -178,7 +183,7 @@ function common () {
 
 # aliases for common gh commands
 # github cli create draft pull request
-alias prc='gh pr create -df'
+alias prc='gh pr create -f'
 
 # github cli view pull request in browser
 alias prv='gh pr view -w'

--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -11,18 +11,18 @@ function noremap(mode, mapping, cmd)
 end
 
 --tab settings
-set.tabstop = 8
-set.softtabstop = 4
-set.shiftwidth = 4
-set.expandtab = true
-set.listchars:append({tab = "->"}) --visualize tabs
+vim.o.tabstop = 8
+vim.o.softtabstop = 4
+vim.o.shiftwidth = 4
+vim.o.expandtab = true
+vim.opt.listchars:append({tab = "->"}) --visualize tabs
 
 --show whitespace at end of line
-set.listchars:append({trail = "."})
-set.list = true
+vim.opt.listchars:append({trail = "."})
+vim.o.list = true
 
---set.line numbering
-set.number = true
+--set line numbering
+vim.o.number = true
 
 --absolute line numbering on non-active windows, relative on active windows.
 vim.api.nvim_create_augroup('numbertoggle', {clear = true})
@@ -33,13 +33,13 @@ augroup END
 ]])
 
 --search options, ignorecase is necessary for smartcase
-set.ignorecase = true
-set.smartcase = true
+vim.o.ignorecase = true
+vim.o.smartcase = true
 
 --split settings, not working with vex
-set.splitbelow = true
-set.splitright = true
-set.fillchars:append({vert = ' '})
+vim.o.splitbelow = true
+vim.o.splitright = true
+vim.opt.fillchars:append({vert = ' '})
 
 --easier file search
 vim.cmd('cabbrev vex Vexplore!')

--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -6,8 +6,9 @@ require('plugins')
 require('colors')
 require('filetypes')
 
--- set local variable for simple conversion to lua
-local set = vim.opt
+function noremap(mode, mapping, cmd)
+    vim.api.nvim_set_keymap(mode, mapping, cmd, { noremap = true, silent = true })
+end
 
 --tab settings
 set.tabstop = 8
@@ -49,33 +50,33 @@ vim.cmd('cabbrev sex Sexplore')
 vim.g.netrw_banner = 0
 
 --quality of life key remaps
-vim.api.nvim_set_keymap('', ';', ':', {noremap = true})
-vim.api.nvim_set_keymap('', ':', ';', {noremap = true})
-vim.api.nvim_set_keymap('n', '<C-h>', '<C-w>h', {noremap = true})
-vim.api.nvim_set_keymap('n', '<C-j>', '<C-w>j', {noremap = true})
-vim.api.nvim_set_keymap('n', '<C-k>', '<C-w>k', {noremap = true})
-vim.api.nvim_set_keymap('n', '<C-l>', '<C-w>l', {noremap = true})
+noremap('', ';', ':')
+noremap('', ':', ';')
+noremap('n', '<C-h>', '<C-w>h')
+noremap('n', '<C-j>', '<C-w>j')
+noremap('n', '<C-k>', '<C-w>k')
+noremap('n', '<C-l>', '<C-w>l')
 
 -- write with sudo trick alias
-vim.api.nvim_set_keymap('c', 'w!!', 'w !sudo tee > /dev/null %', {noremap = true})
+noremap('c', 'w!!', 'w !sudo tee > /dev/null %')
 
 --clear highlight
-vim.api.nvim_set_keymap('', '<leader>c', '<cmd>noh<CR>', {noremap = true})
+noremap('', '<leader>c', '<cmd>noh<CR>')
 
 --save to clipboard (wsl only)
-vim.api.nvim_set_keymap('c', 'wc', 'w !clip.exe', {noremap = true})
+noremap('c', 'wc', 'w !clip.exe')
 
 --reload init.lua
-vim.api.nvim_set_keymap('', '<leader>r', '<cmd>source ~/.config/nvim/init.lua<CR>', {noremap = true})
+noremap('', '<leader>r', '<cmd>source ~/.config/nvim/init.lua<CR>')
 
 ---gmk auth tool
-vim.api.nvim_set_keymap('', '<leader>a', ':vnew\:r !gac ', {noremap = true})
+noremap('', '<leader>a', ':vnew\:r !gac ')
 
 --toggle overlength highlight
-vim.api.nvim_set_keymap('', '<leader>o', ':lua ToggleLineLength()<CR>', {noremap = true, silent = true})
+noremap('', '<leader>o', ':lua ToggleLineLength()<CR>')
 
 --toggle "paste" setting to maintain spacing
-vim.api.nvim_set_keymap('', '<leader>p', ':set invpaste paste?<CR>', {noremap = true, silent = true})
+noremap('', '<leader>p', ':set invpaste paste?<CR>')
 
 
 --set sift to be used by :grep

--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -80,13 +80,11 @@ noremap('', '<leader>p', ':set invpaste paste?<CR>')
 
 
 --set sift to be used by :grep
-vim.cmd([[
-if executable("sift")
-    set grepprg=sift\ --ignore-case\ --filename\ -n
-    set grepformat=%f:%l:%c:%m,%f:%l:%m
-    command! -nargs=+ Sift execute 'silent grep! <args>' | copen
-    map <leader>s ;Sift 
-endif
-]])
+if vim.fn.executable("sift") then
+    vim.o.grepprg="sift --ignore-case --filename -n"
+    vim.o.grepformat="%f:%l:%c:%m,%f:%l:%m"
+    vim.cmd([[command! -nargs=+ Sift execute 'silent grep! <args>' | copen]])
+    noremap('', '<leader>s', ';Sift')
+end
 
 vim.cmd('let $BASH_ENV = "~/.aliases"')

--- a/neovim/lua/colors.lua
+++ b/neovim/lua/colors.lua
@@ -1,5 +1,5 @@
 -- Set a flag to track the line length highlighting status
-local line_length_highlighting_on = false
+local line_length_highlighting_on = true
 
 --highlight characters past the 80th column in red if toggled
 function ToggleLineLength()

--- a/neovim/lua/filetypes.lua
+++ b/neovim/lua/filetypes.lua
@@ -8,3 +8,20 @@ augroup templates
   autocmd BufNewFile *.js 0r ~/.config/nvim/templates/skeleton.js
 augroup END
 ]])
+
+vim.cmd([[
+augroup helpfiles
+  au!
+  au BufEnter */doc/* if &filetype=='help' | wincmd L | endif
+]])
+
+-- large file handling
+vim.cmd([[
+if !exists("my_auto_commands_loaded")
+    let my_auto_commands_loaded = 1
+    let g:LargeFile = 1024 * 1024 * 10
+    augroup LargeFile
+        autocmd BufReadPre * let f=expand("<afile>") | if getfsize(f) > g:LargeFile | set eventignore+=FileType | setlocal noswapfile bufhidden=unload buftype=nowrite undolevels=-1 | else | set eventignore-=FileType | endif
+    augroup END
+endif
+]])


### PR DESCRIPTION
- shortened vim.api.nvim_set_keymap to noremap
- updated old set command to vim.opt & vim.o due to instability
- made the sift-related commands more lua like
- line overlength highlighting now defaults to off
