### PR TITLE
work machine/dev setup overhaul cwm

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ The setup files add some functionality I find important. Things such as a fuzzy 
   - Clone repo & change to repo directory
   - Run `dev-setup.sh`
 
+## The .local_vars file
+This file is for storing more sensitive variables in the local environment while keeping them out of the source control.
+
+Some important variables to define include:
+| Variable    | Description                                                                                           |
+| --------    | -----------                                                                                           |
+| PROJECT_DIR | Used by customized fzf setup to allow fuzzy searching windows files from wsl                          |
+| SSH_ID_FILE | Used to identify the file for ssh to use for git connections, but available for other ssh connections |
+
 ## Dependencies
   - git
   - gh

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -126,5 +126,8 @@ touch $HOME/.local_vars
 chmod +x $HOME/.local_vars
 printf "local variables file created. Can be used for sensitive environment variables.\n"
 
+# create ssh directory if not exists
+mkdir -p ~/.ssh
+
 # restart bash
 exec bash -l

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -18,6 +18,34 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     brew install git gh neovim fd-find
 fi
 
+printf "\n==INSTALL NEOVIM FROM SOURCE==\n"
+if ! command -v nvim >/dev/null; then
+    printf "Neovim is not installed, building from source\n"
+    # build nvim from source
+    pushd /tmp >/dev/null
+    git clone https://github.com/neovim/neovim --depth 5
+    cd neovim
+    git checkout stable
+    rm -rf build/
+    make CMAKE_BUILD_TYPE=RelWithDebInfo CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$HOME/neovim"
+    make install
+    popd >/dev/null
+
+    # Check if PATH update is already in .bashrc and add it if it's not
+    if ! grep -q 'export PATH="$HOME/neovim/bin:$PATH"' $HOME/.bashrc; then
+                echo 'export PATH="$HOME/neovim/bin:$PATH"' >> $HOME/.bashrc
+    fi
+    export PATH="$HOME/neovim/bin:$PATH"
+
+    printf "Neovim installation complete.\n"
+else
+    printf "Neovim already installed\n"
+fi
+
+nvim --version | head -n 1
+
+
+printf "\n==SYMLINK HOME AND NVIM FILES==\n"
 # setup links for config files
 pushd $HOME
 find "$HOME/dotfiles/homedir" -maxdepth 1 -printf '%P\n' | while read file; do ln -s "$HOME/dotfiles/homedir/$file" "$file"; done

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -61,18 +61,42 @@ printf "\n==SET GIT GLOBAL EXCLUDES==\n"
 git config --global core.excludesfile $HOME/.gitignore_global
 
 # install fzf
-git clone --depth 1 https://github.com/junegunn/fzf.git $HOME/.fzf
-$HOME/.fzf/install
+printf "\n==FZF GIT INSTALL==\n"
+if ! command -v nvm >/dev/null; then
+    # git repo is cloned here to make key-binding files available
+    git clone --depth 1 https://github.com/junegunn/fzf.git $HOME/.fzf
+    $HOME/.fzf/install
+    printf "fzf has been installed\n"
+else
+    printf "fzf already installed\n"
+fi
+
+fzf --version | head -n 1
 
 # install node.js with version manage & linter
-pushd $HOME/
-git clone https://github.com/nvm-sh/nvm.git .nvm
-. .nvm/install.sh && nvm install node && npm install -g jshint
-popd
+printf "\n==NVM GIT INSTALL==\n"
+if ! command -v nvm >/dev/null; then
+    pushd $HOME/ >/dev/null
+    git clone https://github.com/nvm-sh/nvm.git .nvm
+    . .nvm/install.sh && nvm install node && npm install -g jshint
+    popd >/dev/null
+    printf "nvm has been installed\n"
+else
+    printf "nvm already installed\n"
+fi
+
+nvm --version | head -n 1
 
 # add plugin manager for vim
-curl -fLo $HOME/.vim/autoload/plug.vim --create-dirs \
-    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+printf "\n==VIMPLUG GIT INSTALL==\n"
+if ! [ -e $HOME/.local/share/nvim/site/autoload/plug.vim ]; then
+    # curl may need -k if dealing with harsh firewall
+    curl -fLo $HOME/.local/share/nvim/site/autoload/plug.vim --create-dirs \
+        https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+    printf "Vimplug has been installed\n"
+else
+    printf "Vimplug already installed\n"
+fi
 
 # install all plugins for vim, then close all open windows
 nvim +PlugInstall +qall
@@ -80,11 +104,25 @@ nvim +PlugInstall +qall
 # add talon & configuration
 
 # add sift
-pushd /tmp
-wget https://sift-tool.org/downloads/sift/sift_0.9.0_linux_amd64.tar.gz && \
-tar xzf sift_0.9.0_linux_amd64.tar.gz && \\
-sudo mv sift_0.9.0_linux_amd64/sift /usr/local/bin/
-popd
+printf "\n==SIFT SOURCE INSTALL==\n"
+if ! command -v sift >/dev/null; then
+    pushd /tmp >/dev/null
+    # wget may need --no-check-certificate if dealing with harsh firewall
+    wget https://sift-tool.org/downloads/sift/sift_0.9.0_linux_amd64.tar.gz && \
+    tar xzf sift_0.9.0_linux_amd64.tar.gz && \
+    sudo mv sift_0.9.0_linux_amd64/sift /usr/local/bin/
+    popd >/dev/null
+    printf "sift has been installed\n"
+else
+    printf "sift already installed\n"
+fi
+
+sift --version | head -n 1
+
+printf "\n==CREATE LOCAL VARIABLES FILE==\n"
+touch $HOME/.local_vars
+chmod +x $HOME/.local_vars
+printf "local variables file created. Can be used for sensitive environment variables.\n"
 
 # restart bash
 exec bash -l

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -47,14 +47,16 @@ nvim --version | head -n 1
 
 printf "\n==SYMLINK HOME AND NVIM FILES==\n"
 # setup links for config files
-pushd $HOME
-find "$HOME/dotfiles/homedir" -maxdepth 1 -printf '%P\n' | while read file; do ln -s "$HOME/dotfiles/homedir/$file" "$file"; done
-popd
-mkdir $HOME/.config/nvim
-pushd $HOME/.config/nvim
-find "$HOME/dotfiles/neovim" -maxdepth 1 -printf '%P\n' | while read file; do ln -s "$HOME/dotfiles/neovim/$file" "$file"; done
-popd
+pushd $HOME >/dev/null
+find "$HOME/dotfiles/homedir" -maxdepth 1 -printf '%P\n' | while read file; do if ! [ -e $file ]; then ln -s "$HOME/dotfiles/homedir/$file" "bkp.$file"; fi done
+popd >/dev/null
+mkdir -p $HOME/.config/nvim
+pushd $HOME/.config/nvim >/dev/null
+find "$HOME/dotfiles/neovim" -maxdepth 1 -printf '%P\n' | while read file; do if ! [ -e $file ]; then ln -s "$HOME/dotfiles/neovim/$file" "bkp.$file"; fi done
+popd >/dev/null
+printf "Symlinks created\n"
 
+printf "\n==SET GIT GLOBAL EXCLUDES==\n"
 # setup global git ignore
 git config --global core.excludesfile $HOME/.gitignore_global
 

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -3,10 +3,14 @@
 # update apt & install some needed libraries if on linux
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     # update system
-    sudo apt update
+    sudo apt -qq update
+    sudo apt -qq upgrade -y
 
-    # gh for github cli, neovim, fd-find for fzf, & xdg-utils & x11-xkb-utils for capslock remap
-    sudo apt install gh neovim xdg-utils x11-xkb-utils fd-find -y
+    # gh for github cli, fd-find for fzf, & xdg-utils & x11-xkb-utils for capslock remap
+    sudo apt -qq install gh golang xdg-utils x11-xkb-utils fd-find -y
+    sudo apt-get -qq install -y ninja-build gettext libtool libtool-bin autoconf automake cmake g++ pkg-config unzip curl doxygen
+
+    sudo apt -qq autoremove -y
 
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     # install homebrew, git, github cli, & neovim if on mac

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -2,11 +2,6 @@
 
 # update apt & install some needed libraries if on linux
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    # is the adding of this keyserver necessary or a good idea?
-    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-    sudo add-apt-repository https://cli.github.com/packages
-    sudo add-apt-repository ppa:neovim-ppa/stable
-
     # update system
     sudo apt update
 

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # update apt & install some needed libraries if on linux
+printf "\n==OS INITIAL SETUP==\n"
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     # update system
     sudo apt -qq update
@@ -100,6 +101,7 @@ fi
 
 # install all plugins for vim, then close all open windows
 nvim +PlugInstall +qall
+printf "Neovim plugins updated/installed\n"
 
 # add talon & configuration
 

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -63,7 +63,7 @@ git config --global core.excludesfile $HOME/.gitignore_global
 
 # install fzf
 printf "\n==FZF GIT INSTALL==\n"
-if ! command -v nvm >/dev/null; then
+if ! command -v fzf >/dev/null; then
     # git repo is cloned here to make key-binding files available
     git clone --depth 1 https://github.com/junegunn/fzf.git $HOME/.fzf
     $HOME/.fzf/install

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -88,6 +88,10 @@ fi
 
 nvm --version | head -n 1
 
+# install latest lts of node
+printf "\n==NODE LATEST LTS INSTALL==\n"
+nvm install --lts
+
 # add plugin manager for vim
 printf "\n==VIMPLUG GIT INSTALL==\n"
 if ! [ -e $HOME/.local/share/nvim/site/autoload/plug.vim ]; then

--- a/homedir/.aliases
+++ b/homedir/.aliases
@@ -188,12 +188,12 @@ alias prv='gh pr view -w'
 function sshgh () {
     if [ $# -eq 2 ]
     then
-        ssh-keygen -t ed25519 -b 256 -C "${2}" -f ~/.ssh/chris
+        ssh-keygen -t ed25519 -b 256 -C "${2}" -f $SSH_ID_FILE
     fi
 }
 
 # ssh restart
-alias rssh='eval $(ssh-agent -s) && ssh-add ~/.ssh/cwmccullough'
+alias rssh='eval $(ssh-agent -s) && ssh-add $SSH_ID_FILE'
 
 # growmark specific aliases
 # growmark authenticator

--- a/homedir/.bashrc
+++ b/homedir/.bashrc
@@ -110,12 +110,6 @@ if ! shopt -oq posix; then
   fi
 fi
 
-# create ssh directory if not exists
-sshdir=~/.ssh
-if [ ! -d "$sshdir" ]; then
-    mkdir ~/.ssh
-fi
-
 # autorun ssh-agent
 # Others have recommended the use of keychain, such as:
 # "eval `keychain --quiet --eval --agents ssh id_rsa`"

--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -9,6 +9,9 @@ require('filetypes')
 -- set local variable for simple conversion to lua
 local set = vim.opt
 
+--disable mouse
+vim.cmd([[set mouse=]])
+
 --tab settings
 set.tabstop = 8
 set.softtabstop = 4

--- a/neovim/lua/plugins.lua
+++ b/neovim/lua/plugins.lua
@@ -16,6 +16,7 @@ vim.call('plug#begin', '~/.vim/plugged') --specify plugin directory
     Plug('pangloss/vim-javascript', {['for'] = 'javascript'}) --JavaScript support
     Plug('leafgarland/typescript-vim', {['for'] = 'typescript'}) --Typescript syntax
     Plug('neoclide/coc.nvim', {branch = 'release'})
+    Plug('github/copilot.vim')
 vim.call('plug#end')
 
 --Ultisnip options


### PR DESCRIPTION
- removed adding keyserver & apt repositories
- added neovim dependencies & the qq apt flag for quieter installs
- build neovim from source for more guaranteed & updated versions
- added checks to symlinks, pipe popd/pushd to /dev/null for quiet, & adjusted mkdir call
- added checks to non-apt installs & created local_vars file in dev setup
- added a couple extra prints for clearer output
- added hushlogin file for clear startups
- fixed fzf installation typo
- moved adding ssh directory to dev-setup.sh
- added command in dev-setup.sh to use nvm to install node latest lts
- disabled mouse in nvim
- added copilot to nvim plugins to test
- added SSH_ID_FILE variable to aliase calls & added var definitions in readme
