### PR TITLE
Ctags Support

### DIFF
--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -38,10 +38,14 @@ augroup END
 set.ignorecase = true
 set.smartcase = true
 
---split settings, not working with vex
+--split settings
 set.splitbelow = true
 set.splitright = true
 set.fillchars:append({vert = ' '})
+
+--ctags configuration
+--this is so ctags files can be in the .git directory to avoid commiting
+vim.opt.tags:prepend('.git/tags;~')
 
 --easier file search
 vim.cmd('cabbrev vex Vexplore!')


### PR DESCRIPTION
Although the title say Ctags Support, this is more about changing the expected location of the tags file that universal-ctags generates. After reading a [blog post](https://tbaggery.com/2011/08/08/effortless-ctags-with-git.html) by Tim Pope, I decided to finally get ctags properly set up & that included moving the expected tags file location.

The main reason for having the tags file in `.git` is to prevent the file from being committed into any repos & being able to utilize git hooks to update it (see blog post above). 