### PR TITLE
ctags git hook templates

### DIFF
--- a/homedir/.git_template/hooks/ctags
+++ b/homedir/.git_template/hooks/ctags
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+PATH="/usr/local/bin:$PATH"
+trap 'rm -f ".git/$$.tags"' EXIT
+git ls-files | ctags --tag-relative -L - -f".git/$$.tags"
+mv ".git/$$.tags" ".git/tags"

--- a/homedir/.git_template/hooks/post-checkout
+++ b/homedir/.git_template/hooks/post-checkout
@@ -1,0 +1,2 @@
+#!/bin/sh
+./git/hooks/ctags >/dev/null 2>&1 &

--- a/homedir/.git_template/hooks/post-commit
+++ b/homedir/.git_template/hooks/post-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+./git/hooks/ctags >/dev/null 2>&1 &

--- a/homedir/.git_template/hooks/post-merge
+++ b/homedir/.git_template/hooks/post-merge
@@ -1,0 +1,2 @@
+#!/bin/sh
+./git/hooks/ctags >/dev/null 2>&1 &

--- a/homedir/.git_template/hooks/post-rewrite
+++ b/homedir/.git_template/hooks/post-rewrite
@@ -1,0 +1,4 @@
+#!/bin/sh
+case "$1" in 
+    rebase) exec .git/hooks/post-merge ;;
+esac


### PR DESCRIPTION
This PR adds the git hooks templates for handling ctags file updates. The git hooks files here are near exact copies of the ones from [tpope's blog](https://tbaggery.com/2011/08/08/effortless-ctags-with-git.html), the only difference being that these put the `tags` file in the `.git` directory.

These git hooks handle updating the tags file anytime there are changes registered in git after checkouts, commits, merges, or rewrites.