### PR TITLE
linting support for neovim

### DIFF
--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -12,6 +12,8 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sudo apt-get -qq install -y ninja-build gettext libtool libtool-bin autoconf automake cmake g++ pkg-config unzip curl doxygen
     # used for ncspot & other cargo packages
     sudo apt -qq install -y libdbus-1-dev libncursesw5-dev libpulse-dev libssl-dev libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
+    # linting programs. Cargo is included, but installed using rustup
+    sudo apt -qq install -y pylint eslint lua shellcheck
 
     sudo apt -qq autoremove -y
 

--- a/neovim/lua/colors.lua
+++ b/neovim/lua/colors.lua
@@ -39,9 +39,9 @@ end
 
 --enact the custom highlights & colors
 vim.api.nvim_create_augroup('CustomColors', {clear = true})
-vim.api.nvim_create_autocmd({"Colorscheme"}, {group = 'CustomColors', pattern = {'*'}, callback = ToggleLineLength})
-vim.api.nvim_create_autocmd({"Colorscheme"}, {group = 'CustomColors', pattern = {'*'}, callback = OtherChars})
-vim.api.nvim_create_autocmd({"Colorscheme"}, {group = 'CustomColors', pattern = {'*'}, callback = Transparent})
+vim.api.nvim_create_autocmd('Colorscheme', {group = 'CustomColors', callback = ToggleLineLength})
+vim.api.nvim_create_autocmd('Colorscheme', {group = 'CustomColors', callback = OtherChars})
+vim.api.nvim_create_autocmd('Colorscheme', {group = 'CustomColors', callback = Transparent})
 
 --theme
 vim.cmd('colorscheme gruvbox8')

--- a/neovim/lua/filetypes.lua
+++ b/neovim/lua/filetypes.lua
@@ -1,29 +1,28 @@
+local augroup = vim.api.nvim_create_augroup
+local autocmd = vim.api.nvim_create_autocmd
+
 --Template Files
-vim.cmd([[
-augroup templates
-  autocmd BufNewFile *.sh 0r ~/.config/nvim/templates/skeleton.sh
-  autocmd BufNewFile *.py 0r ~/.config/nvim/templates/skeleton.py
-  autocmd BufNewFile *.pl 0r ~/.config/nvim/templates/skeleton.pl
-  autocmd BufNewFile *.html 0r ~/.config/nvim/templates/skeleton.html
-  autocmd BufNewFile *.js 0r ~/.config/nvim/templates/skeleton.js
-augroup END
-]])
+local template_cmd = '0r ~/.config/nvim/templates/skeleton'
+augroup('templates', {clear = true})
+autocmd('BufNewFile', {group='templates', pattern='*.sh', command=template_cmd .. '.sh'})
+autocmd('BufNewFile', {group='templates', pattern='*.py', command=template_cmd .. '.py'})
+autocmd('BufNewFile', {group='templates', pattern='*.pl', command=template_cmd .. '.pl'})
+autocmd('BufNewFile', {group='templates', pattern='*.js', command=template_cmd .. '.js'})
+autocmd('BufNewFile', {group='templates', pattern='*.html', command=template_cmd .. '.html'})
 
-vim.cmd([[
-augroup linting
-  autocmd!
-  autocmd FileType python compiler pylint
-  autocmd BufWritePost *.py silent make <afile> | silent redraw!
 
-  autocmd FileType javascript compiler eslint
-  autocmd BufWritePost *.js silent make <afile> | silent redraw!
+--Linting
+local make_cmd = 'silent make <afile> | silent redraw!'
+augroup('linting', {clear = true})
+autocmd('FileType', {group='linting', pattern='python', command='compiler pylint'})
+autocmd('BufWritePost', {group='linting', pattern='*.py', command=make_cmd})
 
-  autocmd FileType bash compiler shellcheck
-  autocmd BufWritePost *.sh silent make <afile> | silent redraw!
+autocmd('FileType', {group='linting', pattern='javascript', command='compiler eslint'})
+autocmd('BufWritePost', {group='linting', pattern='*.js', command=make_cmd})
 
-  autocmd FileType rust compiler cargo
-  autocmd BufWritePost *.rs silent make <afile> | silent redraw!
+autocmd('FileType', {group='linting', pattern='bash', command='compiler shellcheck'})
+autocmd('BufWritePost', {group='linting', pattern='*.sh', command=make_cmd})
 
-  autocmd QuickFixCmdPost [^l]* cwindow
-augroup END
-]])
+autocmd('FileType', {group='linting', pattern='rust', command='compiler cargo'})
+autocmd('BufWritePost', {group='linting', pattern='*.rs', command=make_cmd})
+autocmd('QuickFixCmdPost', {group='linting', command='[^l]* cwindow'})

--- a/neovim/lua/filetypes.lua
+++ b/neovim/lua/filetypes.lua
@@ -25,4 +25,7 @@ autocmd('BufWritePost', {group='linting', pattern='*.sh', command=make_cmd})
 
 autocmd('FileType', {group='linting', pattern='rust', command='compiler cargo'})
 autocmd('BufWritePost', {group='linting', pattern='*.rs', command=make_cmd})
-autocmd('QuickFixCmdPost', {group='linting', command='[^l]* cwindow'})
+
+autocmd('FileType', {group='linting', pattern='lua', command='setlocal makeprg="luac -p % | setlocal errorformat=%m"'})
+autocmd('BufWritePost', {group='linting', pattern='*.lua', command=make_cmd})
+autocmd('QuickFixCmdPost', {group='linting', pattern='[^l]*', command='cwindow'})

--- a/neovim/lua/filetypes.lua
+++ b/neovim/lua/filetypes.lua
@@ -8,3 +8,22 @@ augroup templates
   autocmd BufNewFile *.js 0r ~/.config/nvim/templates/skeleton.js
 augroup END
 ]])
+
+vim.cmd([[
+augroup linting
+  autocmd!
+  autocmd FileType python compiler pylint
+  autocmd BufWritePost *.py silent make <afile> | silent redraw!
+
+  autocmd FileType javascript compiler eslint
+  autocmd BufWritePost *.js silent make <afile> | silent redraw!
+
+  autocmd FileType bash compiler shellcheck
+  autocmd BufWritePost *.sh silent make <afile> | silent redraw!
+
+  autocmd FileType rust compiler cargo
+  autocmd BufWritePost *.rs silent make <afile> | silent redraw!
+
+  autocmd QuickFixCmdPost [^l]* cwindow
+augroup END
+]])

--- a/neovim/lua/plugins.lua
+++ b/neovim/lua/plugins.lua
@@ -16,7 +16,6 @@ vim.call('plug#begin', '~/.vim/plugged') --specify plugin directory
     Plug('pangloss/vim-javascript', {['for'] = 'javascript'}) --JavaScript support
     Plug('leafgarland/typescript-vim', {['for'] = 'typescript'}) --Typescript syntax
     Plug('neoclide/coc.nvim', {branch = 'release'})
-    Plug('github/copilot.vim')
 vim.call('plug#end')
 
 --Ultisnip options

--- a/neovim/lua/plugins.lua
+++ b/neovim/lua/plugins.lua
@@ -13,9 +13,6 @@ vim.call('plug#begin', '~/.vim/plugged') --specify plugin directory
     Plug 'Sirver/ultisnips' --snippet plugin
     Plug 'lifepillar/vim-gruvbox8' --updated colorscheme
     Plug 'vimwiki/vimwiki' --vim wiki
-    Plug('pangloss/vim-javascript', {['for'] = 'javascript'}) --JavaScript support
-    Plug('leafgarland/typescript-vim', {['for'] = 'typescript'}) --Typescript syntax
-    Plug('neoclide/coc.nvim', {branch = 'release'})
 vim.call('plug#end')
 
 --Ultisnip options
@@ -27,9 +24,3 @@ vim.cmd [[
 let g:UltiSnipsSnippetDirectories=[$HOME.'/.config/nvim/UltiSnips']
 ]]
 vim.cmd('cabbrev snip UltiSnipsEdit')
-
---CoC options
-vim.cmd [[
-let g:coc_global_extensions=['coc-tsserver']
-]]
-vim.g.coc_disable_startup_warning = 1


### PR DESCRIPTION
The PR adds linting support to neovim for lua, bash, python, javascript, & rust.

Closes #46 
- **added linting autocmds to filestype.lua & removed copilot. Again.**
- **rewrote file specific autocmds in lua & removed old linting plugins**
- **removed pattern from hightlight & coloring autocmds, they default to * anyway so they are not needed.**
- **added support for the lua linter more manually with makeprg & errorfo…**
- **added linting programs install to dev-setup.sh**
